### PR TITLE
開発コンテナの作成とREADMEへの追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,28 @@ Starting chousei-front ... done
 ```
 コンテナ起動後、http://localhost:8080 にアクセス。
 
+## Frontのみを開発用のコンテナで起動するパターン
+コンテナをdocker-compose.develop.ymlで立ち上げる
+```
+$ repository\chousei> docker-compose -f docker-compose.develop.yml up -d  
+略
+```
+
+コンテナにアクセスし準備する
+```
+$ repository\chousei> docker-compose exec chousei-front sh
+
+/usr/src/app # yarn
+yarn install v1.21.1
+info No lockfile found.
+[1/5] Validating package.json...
+略
+
+/usr/src/app # quasar dev
+```
+もしくはこちらで直接実行する（node_modulesがある前提）
+```
+docker-compose exec chousei-front quasar dev
+```
 ## Front,APIのローカルデバッグ方法
 各ディレクトリのREADMEに書いてあります。

--- a/api/Dockerfile_api_dev
+++ b/api/Dockerfile_api_dev
@@ -1,0 +1,3 @@
+# ビルド環境
+FROM node:10
+WORKDIR /usr/src/app

--- a/api/Dockerfile_api_dev
+++ b/api/Dockerfile_api_dev
@@ -1,3 +1,4 @@
 # ビルド環境
 FROM node:10
 WORKDIR /usr/src/app
+RUN npm install -g nodemon

--- a/api/config/config.json
+++ b/api/config/config.json
@@ -1,8 +1,7 @@
 {
   "development": {
-    "url": "postgres://chousei:chousei@localhost:15432/chousei",
+    "url": "postgres://chousei:chousei@chousei-db:5432/chousei",
     "loggerLevel": "debug",
-    "port": 15432,
     "arrowFrontUrl": "http://localhost:8081"
   },
   "production": {

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,0 +1,43 @@
+---
+version: '2'
+
+services:
+  chousei-db:
+    image: postgres:10-alpine
+    container_name: chousei-db
+    environment:
+      POSTGRES_DB: chousei
+      POSTGRES_USER: chousei
+      POSTGRES_PASSWORD: chousei
+      LANG: ja_JP.UTF-8
+    volumes:
+      - ./db/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./db/sql:/docker-entrypoint-initdb.d
+    ports:
+      - 15432:5432
+
+  chousei-api:
+    build: ./api
+    image: chousei-api
+    container_name: chousei-api
+    environment:
+      NODE_ENV: production
+    hostname: "chousei-api"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - chousei-db
+
+  chousei-front:
+    build: 
+      context: ./front
+      dockerfile: Dockerfile_front_dev
+    container_name: chousei-front-dev
+    hostname: "chouseiFront"
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./front:/usr/src/app
+    stdin_open: true
+    tty: true
+    command: /bin/sh

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -17,16 +17,23 @@ services:
       - 15432:5432
 
   chousei-api:
-    build: ./api
+    build: 
+      context: ./api
+      dockerfile: Dockerfile_api_dev
     image: chousei-api
-    container_name: chousei-api
+    container_name: chousei-api-dev
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
     hostname: "chousei-api"
     ports:
       - "3000:3000"
     depends_on:
       - chousei-db
+    volumes:
+      - ./api:/usr/src/app
+    stdin_open: true
+    tty: true
+    command: /bin/sh
 
   chousei-front:
     build: 

--- a/front/Dockerfile_front_dev
+++ b/front/Dockerfile_front_dev
@@ -1,0 +1,5 @@
+# ビルド環境
+FROM node:13.7-alpine
+WORKDIR /usr/src/app
+RUN apk update && \
+    npm install -g @quasar/cli


### PR DESCRIPTION
## これをマージすると
- コンテナ上で開発ができるようになります。
- ローカルにquasar devがなくても実行できます。
- （5/23追記）注意！apiもコンテナ上で開発するように設定値を変更しました。ここが問題ある場合はコメントください。

## 使い方
### 共通
コンテナをdocker-compose.develop.ymlで立ち上げる
```
$ repository\chousei> docker-compose -f docker-compose.develop.yml up -d  
略
```

### Front
コンテナにアクセスし準備する
```
$ repository\chousei> docker-compose exec chousei-front sh

/usr/src/app # yarn
yarn install v1.21.1
info No lockfile found.
[1/5] Validating package.json...
略

/usr/src/app # quasar dev
```
もしくはこちらで直接実行する（node_modulesがある前提）
```
docker-compose exec chousei-front quasar dev
```

### Api
初回のみ
```
$ repository\chousei> docker-compose exec chousei-api sh

/usr/src/app # npm install
[1/5] Validating package.json...
略

/usr/src/app # exit
```

もしくはこちらで直接実行する（node_modulesがある前提）

```
docker-compose exec chousei-api node index
```